### PR TITLE
Import built C-API of polo

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Martin Biel <martinbiel93@gmail.com>"]
 version = "0.1.0"
 
 [deps]
+BinaryProvider = "b99e7846-7c00-51b0-8f62-c81ae34c0232"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -1,0 +1,11 @@
+using BinaryProvider
+
+products = Product[
+  LibraryProduct("/usr/local/lib", "libpoloapi", :libpolo),
+]
+
+if any(!satisfied(p) for p in products)
+  error("POLO is not installed properly on your system.")
+end
+
+write_deps_file(joinpath(@__DIR__, "deps.jl"), products)

--- a/src/load_library.jl
+++ b/src/load_library.jl
@@ -15,8 +15,17 @@ macro load_polo_algorithm(algname)
     end
 end
 
+# Load in `deps.jl`, complaining if it does not exist
+const depsjl_path = joinpath(dirname(@__FILE__), "..", "deps", "deps.jl")
+if !isfile(depsjl_path)
+    error("POLO not installed properly, run Pkg.build(\"POLO\"), restart Julia and try again")
+end
+include(depsjl_path)
+
 function __init__()
-    global polo_lib = Libdl.dlopen(joinpath(dirname(@__FILE__), "../", "install", "lib", "libapi.so"));
+    check_deps()
+
+    global polo_lib = Libdl.dlopen(libpolo)
 
     # POLO solvers
     @load_polo_algorithm(gradient)


### PR DESCRIPTION
Using `BinaryProvider`, imported the compiled C-API of `polo` to be used
in `POLO.jl`. Works in our Docker images. Users currently need to
install `polo` by themselves.

TODO: Try to use `BinaryBuilder` to provide cross compiled binaries. For
now, for our purposes, this solution is OK. Maybe a `cmake`-based
installer script could be added to install the C-API under the user's
`julia` folder instead of the current (bad-practice) of enforcing
`/usr/local/lib`.

Closes #1.